### PR TITLE
50 ifcb read mat is not returning data in same struct as read mat

### DIFF
--- a/R/ifcb_extract_biovolumes.R
+++ b/R/ifcb_extract_biovolumes.R
@@ -305,7 +305,5 @@ ifcb_extract_biovolumes <- function(feature_files, mat_folder = NULL, custom_ima
     )) %>%
     select(-biovolume, -is_diatom)
 
-  biovolume_df <- type_convert(biovolume_df)
-
-  return(biovolume_df)
+  type_convert(biovolume_df)
 }

--- a/R/ifcb_extract_biovolumes.R
+++ b/R/ifcb_extract_biovolumes.R
@@ -305,5 +305,7 @@ ifcb_extract_biovolumes <- function(feature_files, mat_folder = NULL, custom_ima
     )) %>%
     select(-biovolume, -is_diatom)
 
+  biovolume_df <- type_convert(biovolume_df)
+
   return(biovolume_df)
 }

--- a/R/ifcb_py_install.R
+++ b/R/ifcb_py_install.R
@@ -9,6 +9,14 @@
 #'
 #' @return No return value. This function is called for its side effect of configuring the Python environment.
 #'
+#' @details
+#' This function requires Python to be available on the system. It uses the `reticulate` package to
+#' manage Python environments and packages.
+#'
+#' The `USE_IRFCB_PYTHON` environment variable can be set to automatically activate an
+#' installed Python virtual environment named `iRfcb` when the `iRfcb` package is loaded.
+#' Set `USE_IRFCB_PYTHON` to `"TRUE"` to enable automatic setup. For more details, see the package README.
+#'
 #' @examples
 #' \dontrun{
 #' # Install the iRfcb Python environment using a virtual environment (default)

--- a/R/ifcb_read_mat.R
+++ b/R/ifcb_read_mat.R
@@ -1,4 +1,4 @@
-utils::globalVariables("read_mat_file")
+utils::globalVariables("r_read_mat_file")
 #' Read a MATLAB .mat File in R
 #'
 #' This function reads a MATLAB `.mat` file using a Python function via `reticulate`.
@@ -28,5 +28,22 @@ ifcb_read_mat <- function(file_path) {
   reticulate::source_python(system.file("python", "read_mat_file.py", package = "iRfcb"))
 
   # Call the Python function
-  read_mat_file(file_path)
+  py_data <- r_read_mat_file(file_path)
+
+  # Converts lists to matrices to ressemble R.matlab::readMat
+  convert_lists_to_matrix <- function(x) {
+    lapply(x, function(el) {
+      if (is.list(el)) {
+        # Convert 1x1 list to 1x1 matrix if it's a scalar string
+        if (length(el) == 1 && is.character(el[[1]])) {
+          matrix(el[[1]], nrow = 1, ncol = 1)
+        }
+      } else {
+        el
+      }
+    })
+  }
+
+  # Convert Python lists to R matrices where appropriate
+  convert_lists_to_matrix(py_data)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,4 +26,20 @@
 
   # List required packages
   reticulate::py_require(reqs)
+
+  # Check if the system environment variable USE_IFCB_PYTHON is set
+  if (Sys.getenv("USE_IRFCB_PYTHON") == "TRUE") {
+
+    # Check if Python venvs are available
+    venv_list <- reticulate::virtualenv_list()
+
+    # Check if any iRfcb virtual environments are available
+    if (length(venv_list) > 0) {
+      iRfcb_venvs <- venv_list[grepl("iRfcb", venv_list)]
+      if (length(iRfcb_venvs) > 0) {
+        # Use exisiting venv
+        ifcb_py_install(iRfcb_venvs[1])
+      }
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,39 @@ To access a feature from the development version of `iRfcb`, install the latest 
 remotes::install_github("EuropeanIFCBGroup/iRfcb")
 ```
 
-Some functions in `iRfcb` require Python. You can download Python from the official website: [python.org/downloads](https://www.python.org/downloads/). For more details, please visit the project's [webpage](https://europeanifcbgroup.github.io/iRfcb/).
+### Python Dependency
+
+Some functions in `iRfcb` require Python. You can download Python from the official website: [python.org/downloads](https://www.python.org/downloads/). For details on what function that require Python, please visit the project's [Function Reference](https://europeanifcbgroup.github.io/iRfcb/reference/).
+
+The `iRfcb` package can be configured to automatically activate an installed Python virtual environment (venv) upon loading by setting an environment variable. This feature is especially useful for users who regularly interact with Python dependencies within the `iRfcb` package.
+
+#### USE_IRFCB_PYTHON
+
+- **Description**: The `USE_IRFCB_PYTHON` environment variable controls whether the package automatically uses a Python virtual environment named `iRfcb` for use when needed.
+- **Default**: By default, this environment variable is not set. This means that the Python environment will not be loaded automatically, and the user must call the `ifcb_py_install` functions manually before using a Python feature.
+- **Usage**: To enable automatic setup of the Python environment when `iRfcb` is loaded, set `USE_IRFCB_PYTHON` to `"TRUE"`.
+
+##### How to Set the `USE_IRFCB_PYTHON` Variable
+
+You can set the `USE_IRFCB_PYTHON` variable in your R session or make it persistent across sessions:
+
+1. **Temporary for the session**: 
+   You can set the variable in your R session before loading `iRfcb` using the following command:
+   ```r
+   Sys.setenv(USE_IRFCB_PYTHON = "TRUE")
+   ```
+
+2. **Permanent across sessions**:
+   To ensure this setting persists across R sessions, add it to your `.Renviron` file in your R home directory. You can easily edit the file using the following command:
+   ```r
+   usethis::edit_r_environ("user")
+   ```
+   
+   Then, add the following line to the file:
+   ```text
+   USE_IRFCB_PYTHON=TRUE
+   ```
+   This will automatically set the environment variable each time you start an R session.
 
 ## Documentation and Tutorials
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The `iRfcb` package can be configured to automatically activate an installed Pyt
 
 #### USE_IRFCB_PYTHON
 
-- **Description**: The `USE_IRFCB_PYTHON` environment variable controls whether the package automatically uses a Python virtual environment named `iRfcb` for use when needed.
+- **Description**: The `USE_IRFCB_PYTHON` environment variable controls whether the package automatically activates a pre-installed Python virtual environment named `iRfcb` when the package is loaded.
 - **Default**: By default, this environment variable is not set. This means that the Python environment will not be loaded automatically, and the user must call the `ifcb_py_install` functions manually before using a Python feature.
-- **Usage**: To enable automatic setup of the Python environment when `iRfcb` is loaded, set `USE_IRFCB_PYTHON` to `"TRUE"`.
+- **Usage**: To enable automatic setup of the Python environment when `iRfcb` is loaded, set `USE_IRFCB_PYTHON` to `"TRUE"`. Ensure that a virtual environment named `iRfcb` is installed (e.g. through `ifcb_py_install`) and available via `reticulate::virtualenv_list()`.
 
 ##### How to Set the `USE_IRFCB_PYTHON` Variable
 

--- a/inst/python/read_mat_file.py
+++ b/inst/python/read_mat_file.py
@@ -27,8 +27,8 @@ def convert_data(x):
             return x
 
     if isinstance(x, list):
-        def flatten(l):
-            for item in l:
+        def flatten(lst):
+            for item in lst:
                 if isinstance(item, list):
                     yield from flatten(item)
                 else:

--- a/inst/python/read_mat_file.py
+++ b/inst/python/read_mat_file.py
@@ -1,32 +1,75 @@
+import numpy as np
 import scipy.io
+
+def convert_data(x):
+    import numpy as np
+
+    if isinstance(x, dict):
+        return {k: convert_data(v) for k, v in x.items()}
+
+    if isinstance(x, str):
+        # Wrap plain strings in [[ ]] to mimic 1x1 character matrix in R
+        return [[x]]
+
+    if isinstance(x, np.ndarray):
+        if np.issubdtype(x.dtype, np.integer):
+            # Convert integers to float (R.matlab reads all numbers as numeric)
+            x = x.astype(np.float64)
+            if x.ndim == 1:
+                x = x.reshape(-1, 1)  # Convert 1D array to column vector
+            return x
+        elif x.dtype == np.object_:
+            flat = [str(item) for item in x.flat]
+            return flat
+        else:
+            if x.ndim == 1:
+                x = x.reshape(-1, 1)  # Convert 1D numeric arrays to column vector
+            return x
+
+    if isinstance(x, list):
+        def flatten(l):
+            for item in l:
+                if isinstance(item, list):
+                    yield from flatten(item)
+                else:
+                    yield item
+        return [str(item) for item in flatten(x)]
+
+    return x
 
 def read_mat_file(file_path):
     """
     Reads a MATLAB .mat file and returns a dictionary with the contents.
-    Compatible with reticulate in R.
+    The function flattens MATLAB cell arrays to Python lists of strings
+    for compatibility with the R version using R.matlab::readMat.
     
     Parameters:
-    file_path (str): Path to the .mat file.
+      file_path (str): Path to the .mat file.
     
     Returns:
-    dict: A dictionary with the MATLAB variables.
+      dict: A dictionary with MATLAB variables.
     """
+    # Load the .mat file; squeeze_me=True reduces singleton dimensions
+    # and struct_as_record=False avoids converting MATLAB structs to record arrays.
     data = scipy.io.loadmat(file_path, squeeze_me=True, struct_as_record=False)
     
-    # Remove MATLAB metadata keys
+    # Remove MATLAB metadata keys (those starting with '__')
     data = {key: value for key, value in data.items() if not key.startswith('__')}
+    
+    # Convert list-like items to a list of strings (if applicable)
+    data = {key: convert_data(value) for key, value in data.items()}
     
     return data
 
-# R Function Wrapper
+# R Function Wrapper for use with reticulate
 def r_read_mat_file(file_path):
     """
     Wrapper function to be used in R via reticulate.
     
     Parameters:
-    file_path (str): Path to the .mat file.
+      file_path (str): Path to the .mat file.
     
     Returns:
-    dict: A dictionary with MATLAB variables, converted for R compatibility.
+      dict: A dictionary with MATLAB variables, converted for R compatibility.
     """
     return read_mat_file(file_path)

--- a/man/ifcb_py_install.Rd
+++ b/man/ifcb_py_install.Rd
@@ -24,6 +24,14 @@ No return value. This function is called for its side effect of configuring the 
 This function sets up the Python environment for \code{iRfcb}. By default, it creates and activates a Python virtual environment (\code{venv}) named "iRfcb" and installs the required Python packages from the "requirements.txt" file.
 Alternatively, users can opt to use the system Python instead of creating a virtual environment by setting \code{use_venv = FALSE} (not recommended).
 }
+\details{
+This function requires Python to be available on the system. It uses the \code{reticulate} package to
+manage Python environments and packages.
+
+The \code{USE_IRFCB_PYTHON} environment variable can be set to automatically activate an
+installed Python virtual environment named \code{iRfcb} when the \code{iRfcb} package is loaded.
+Set \code{USE_IRFCB_PYTHON} to \code{"TRUE"} to enable automatic setup. For more details, see the package README.
+}
 \examples{
 \dontrun{
 # Install the iRfcb Python environment using a virtual environment (default)

--- a/tests/testthat/test-ifcb_extract_annotated_images.R
+++ b/tests/testthat/test-ifcb_extract_annotated_images.R
@@ -105,6 +105,9 @@ test_that("ifcb_extract_annotated_images handles errors gracefully", {
   ), "Empty .mat file"
   )
 
+  # Remove empty file
+  unlink(file.path(manual_folder, "D20220124T144202_IFCB139.mat"))
+
   # Create the output directory
   if (!dir.exists(out_folder)) {
     dir.create(out_folder)

--- a/tests/testthat/test-ifcb_extract_biovolumes.R
+++ b/tests/testthat/test-ifcb_extract_biovolumes.R
@@ -16,7 +16,26 @@ class2use_file <- file.path(temp_dir, "test_data/config/class2use.mat")
 test_that("ifcb_extract_biovolumes works correctly", {
 
   # Run the function with test data
-  biovolume_df <- ifcb_extract_biovolumes(feature_folder, class_folder, micron_factor = 1 / 3.4, diatom_class = "Bacillariophyceae", threshold = "opt", multiblob = FALSE)
+  biovolume_df <- ifcb_extract_biovolumes(feature_folder,
+                                          class_folder,
+                                          micron_factor = 1 / 3.4,
+                                          diatom_class = "Bacillariophyceae",
+                                          threshold = "opt",
+                                          multiblob = FALSE)
+
+  # Run the function with test data
+  biovolume_py <- ifcb_extract_biovolumes(feature_folder,
+                                          class_folder,
+                                          micron_factor = 1 / 3.4,
+                                          diatom_class = "Bacillariophyceae",
+                                          threshold = "opt",
+                                          multiblob = FALSE,
+                                          use_python = TRUE)
+
+  # Check that the .mat data from R and Python are identical
+  expect_identical(biovolume_df$sample, biovolume_py$sample)
+  expect_identical(biovolume_df$biovolume_um3, biovolume_py$biovolume_um3)
+  expect_identical(biovolume_df$roi_number, biovolume_py$roi_number)
 
   # Check that the returned object is a data frame
   expect_s3_class(biovolume_df, "data.frame")

--- a/tests/testthat/test-ifcb_extract_classified_images.R
+++ b/tests/testthat/test-ifcb_extract_classified_images.R
@@ -40,6 +40,25 @@ test_that("ifcb_extract_classified_images works correctly with default parameter
   extracted_images <- list.files(out_folder, pattern = "\\.png$", full.names = TRUE, recursive = TRUE)
   expect_true(length(extracted_images) > 0)
 
+  unlink(out_folder, recursive = TRUE)
+
+  # Run the function by reading .mat files using Python
+  ifcb_extract_classified_images(
+    sample = sample,
+    classified_folder = classified_folder,
+    roi_folder = roi_folder,
+    out_folder = out_folder,
+    taxa = "All",
+    threshold = "opt",
+    use_python = TRUE
+  )
+
+  # Verify that the output directory contains the extracted images
+  extracted_images_py <- list.files(out_folder, pattern = "\\.png$", full.names = TRUE, recursive = TRUE)
+
+  # Check that the images extracted using Python are identical to those extracted using R
+  expect_identical(extracted_images, extracted_images_py)
+
   # Clean up temporary files
   unlink(temp_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-ifcb_get_mat_variable.R
+++ b/tests/testthat/test-ifcb_get_mat_variable.R
@@ -9,6 +9,12 @@ test_that("ifcb_get_mat_variable correctly retrieves a specified variable from a
   # Call the function to get the 'class2use' variable
   classes <- ifcb_get_mat_variable(mat_file, "classifierName")
 
+  # Call the function to get the 'class2use' variable using Python
+  classes_py <- ifcb_get_mat_variable(mat_file, "classifierName", use_python = TRUE)
+
+  # Expect that the .mat data from R and Python are identical
+  expect_identical(classes, classes_py)
+
   # Check if the retrieved classes are as expected (assuming you know the expected classes)
   expected_classes <- "Z:\\data\\manual\\Skagerrak-Kattegat\\summary\\results_21May202421May2024"
   expect_equal(classes[1], expected_classes, info = "Retrieved classes should match expected values")

--- a/tests/testthat/test-ifcb_replace_mat_values.R
+++ b/tests/testthat/test-ifcb_replace_mat_values.R
@@ -38,7 +38,7 @@ test_that("ifcb_replace_mat_values correctly updates the .mat classlist files", 
   expect_warning(ifcb_replace_mat_values(manual_folder, out_folder, target_id, new_id, column_index), "Empty .mat file")
 
   # Clean up the temporary virtual environment
-  unlink(manual_folder)
+  unlink(manual_folder, recursive = TRUE)
 })
 
 test_that("ifcb_replace_mat_values handles missing manual folder gracefully", {

--- a/tests/testthat/test-ifcb_summarize_class_counts.R
+++ b/tests/testthat/test-ifcb_summarize_class_counts.R
@@ -14,6 +14,12 @@ test_that("ifcb_summarize_class_counts works correctly", {
   # Call the function to summarize class counts
   summary_data <- ifcb_summarize_class_counts(classpath_generic, hdr_folder, year_range)
 
+  # Call the function using Python
+  summary_data_py <- ifcb_summarize_class_counts(classpath_generic, hdr_folder, year_range, use_python = TRUE)
+
+  # Expect that the .mat data from R and Python are identical
+  expect_identical(summary_data, summary_data_py)
+
   # Check that the summary data has the correct structure and elements
   expect_type(summary_data, "list")
   expect_named(summary_data, c("class2useTB", "classcountTB", "classcountTB_above_optthresh", "ml_analyzedTB", "mdateTB", "filelistTB", "classpath_generic", "classcountTB_above_adhocthresh", "adhocthresh"))

--- a/vignettes/image-export-tutorial.Rmd
+++ b/vignettes/image-export-tutorial.Rmd
@@ -25,6 +25,10 @@ You can install the package from CRAN using:
 install.packages("iRfcb")
 ```
 
+Some functions from the `iRfcb` package used in this tutorial require `Python` to be installed. You can download `Python` from the official website: [python.org/downloads](https://www.python.org/downloads/).
+
+The `iRfcb` package can be configured to automatically activate an installed Python virtual environment (venv) upon loading by setting an environment variable. For more details, please refer to the package [README](../..).
+
 Load the `iRfcb` library:
 ```{r, eval=FALSE}
 library(iRfcb)

--- a/vignettes/matlab-tutorial.Rmd
+++ b/vignettes/matlab-tutorial.Rmd
@@ -24,6 +24,8 @@ install.packages("iRfcb")
 ```
 Some functions from the `iRfcb` package used in this tutorial require `Python` to be installed. You can download `Python` from the official website: [python.org/downloads](https://www.python.org/downloads/).
 
+The `iRfcb` package can be configured to automatically activate an installed Python virtual environment (venv) upon loading by setting an environment variable. For more details, please refer to the package [README](../..).
+
 Load the `iRfcb` library:
 ```{r, eval=FALSE}
 library(iRfcb)

--- a/vignettes/qc-tutorial.Rmd
+++ b/vignettes/qc-tutorial.Rmd
@@ -30,6 +30,8 @@ install.packages("iRfcb")
 ```
 Some functions from the `iRfcb` package used in this tutorial require `Python` to be installed. You can download `Python` from the official website: [python.org/downloads](https://www.python.org/downloads/).
 
+The `iRfcb` package can be configured to automatically activate an installed Python virtual environment (venv) upon loading by setting an environment variable. For more details, please refer to the package [README](../..).
+
 Load the `iRfcb` and `ggplot2` libraries:
 ```{r, eval=FALSE}
 library(iRfcb)

--- a/vignettes/whoi-plankton-data-integration.Rmd
+++ b/vignettes/whoi-plankton-data-integration.Rmd
@@ -24,6 +24,8 @@ install.packages("iRfcb")
 ```
 Some functions from the `iRfcb` package used in this tutorial require `Python` to be installed. You can download `Python` from the official website: [python.org/downloads](https://www.python.org/downloads/).
 
+The `iRfcb` package can be configured to automatically activate an installed Python virtual environment (venv) upon loading by setting an environment variable. For more details, please refer to the package [README](../..).
+
 Load the `iRfcb` library:
 ```{r, eval=FALSE}
 library(iRfcb)


### PR DESCRIPTION
- convert data loaded by `SciPy` to more closely resemble the output from `R.matlab::readMat()`
- add tests to verify identical output when setting `use_python = TRUE`
- add option to set environmental variable `USE_IRFCB_PYTHON` to automatically activate `iRfcb` python virtual environment when package is loaded