### PR TITLE
feat: add custom_cell_counts for chain counts with custom classificat…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: iRfcb
 Title: Tools for Managing Imaging FlowCytobot (IFCB) Data
-Version: 0.10.0
+Version: 0.10.0.9000
 Authors@R: c(
     person("Anders", "Torstensson", email = "anders.torstensson@smhi.se", role = c("aut", "cre"),
            comment = c("Swedish Meteorological and Hydrological Institute", ORCID = "0000-0002-8283-656X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# iRfcb (development version)
+
+## New features
+
+* `ifcb_extract_biovolumes()` and `ifcb_summarize_biovolumes()` gain a `custom_cell_counts` argument, so `use_cell_counts = TRUE` (and with it `carbon_conversion = "cell"`) now works with `custom_images`/`custom_classes`, which previously could not use chain-count abundance or per-cell carbon at all. The counts are matched to `custom_images` by position and follow the same semantics as counts read from classification files, including `NA` marking a ROI without chain-count data, which makes the affected sample's `cell_counts` `NA` rather than a silent partial sum. Invalid input (wrong length, all-`NA`, counts without `custom_images` or without `use_cell_counts = TRUE`) fails with an error saying what to change.
+
 # iRfcb 0.10.0
 
 ## New features

--- a/R/ifcb_extract_biovolumes.R
+++ b/R/ifcb_extract_biovolumes.R
@@ -19,6 +19,13 @@ utils::globalVariables(c("biovolume", "roi", "roi_number", "Biovolume", "cell_co
 #'        These filenames should match the `roi_number` assignment in the `feature_files` and can be
 #'        used as a substitute for classification files.
 #' @param custom_classes (Optional) A character vector of corresponding class labels for `custom_images`.
+#' @param custom_cell_counts (Optional) An integer vector of raw per-ROI chain counts
+#'        corresponding to `custom_images` by position, as produced by the diatom chain
+#'        counter (the `cell_count` data in `.mat`/`.h5`/`.csv` classification files).
+#'        Sentinel values (`-1` for ROIs the counter skipped, `0` where it found no
+#'        cells) and `NA` (no chain-count data for that ROI) are allowed and resolved
+#'        exactly as when reading `class_files`; see `single_cell_values`. Requires
+#'        `use_cell_counts = TRUE`. Default: NULL.
 #' @param class2use_file (Optional) A character string specifying the path to the file containing the `class2use` variable. Only required for manual results (default: NULL).
 #' @param micron_factor Conversion factor from microns per pixel (default: 1/3.4).
 #' @param diatom_class A character vector specifying diatom class names in WoRMS. Default: `"Bacillariophyceae"`.
@@ -55,8 +62,9 @@ utils::globalVariables(c("biovolume", "roi", "roi_number", "Biovolume", "cell_co
 #' @param use_cell_counts Logical. If `TRUE`, reads the optional per-ROI `cell_count`
 #'        data stored by the diatom chain counter in `.mat`/`.h5`/`.csv` classification files and
 #'        adds `cell_count` (raw) and `cell_count_resolved` (resolved abundance) columns to the
-#'        output. Only supported with automated `class_files`; not with manual files
-#'        or `custom_images`. Default: `FALSE`.
+#'        output. Supported with automated `class_files`, or with `custom_images` when
+#'        the counts are supplied via `custom_cell_counts`; not with manual files.
+#'        Default: `FALSE`.
 #' @param single_cell_values Integer vector of `cell_count` values that should be treated
 #'        as a single cell when resolving `cell_count_resolved`. Default is `c(-1, 0)`, i.e. ROIs that
 #'        were not counted (`-1`) and ROIs where no cells were detected (`0`) each count as one
@@ -96,6 +104,7 @@ utils::globalVariables(c("biovolume", "roi", "roi_number", "Biovolume", "cell_co
 #' - **Classification Data Handling:**
 #'   - If `class_files` is provided, the function reads class annotations from `.mat`, `.h5`, or `.csv` files.
 #'   - If `custom_images` and `custom_classes` are supplied, they override classification file data (e.g. data from a CNN model).
+#'     Chain counts can then be supplied per image via `custom_cell_counts` to use `use_cell_counts = TRUE`.
 #'   - If both `class_files` and `custom_images/custom_classes` are given, `class_files` takes precedence.
 #'
 #' - **MAT File Processing:**
@@ -150,6 +159,7 @@ utils::globalVariables(c("biovolume", "roi", "roi_number", "Biovolume", "cell_co
 #'
 #' @seealso \code{\link{ifcb_read_features}} \code{\link{ifcb_is_diatom}} \code{\link{ifcb_summarize_cell_counts}} \url{https://github.com/nodc-sweden/ifcb-pytorch-classify} \url{https://www.marinespecies.org/}
 ifcb_extract_biovolumes <- function(feature_files, class_files = NULL, custom_images = NULL, custom_classes = NULL,
+                                    custom_cell_counts = NULL,
                                     class2use_file = NULL, micron_factor = 1 / 3.4,
                                     diatom_class = "Bacillariophyceae", diatom_include = NULL, marine_only = FALSE,
                                     diatom_equation = c("large", "all", "auto"),
@@ -190,10 +200,17 @@ ifcb_extract_biovolumes <- function(feature_files, class_files = NULL, custom_im
   }
 
   if (!is.null(class_files) && (!is.null(custom_images) || !is.null(custom_classes))) {
-    cli_warn(c(
-      "Both {.arg class_files} and {.arg custom_images}/{.arg custom_classes} were provided.",
-      "i" = "Using {.arg class_files} and ignoring {.arg custom_images}/{.arg custom_classes}."
-    ))
+    if (is.null(custom_cell_counts)) {
+      cli_warn(c(
+        "Both {.arg class_files} and {.arg custom_images}/{.arg custom_classes} were provided.",
+        "i" = "Using {.arg class_files} and ignoring {.arg custom_images}/{.arg custom_classes}."
+      ))
+    } else {
+      cli_warn(c(
+        "Both {.arg class_files} and {.arg custom_images}/{.arg custom_classes} were provided.",
+        "i" = "Using {.arg class_files} and ignoring {.arg custom_images}/{.arg custom_classes}/{.arg custom_cell_counts}."
+      ))
+    }
   }
 
   if (is.character(feature_files)) {
@@ -255,10 +272,31 @@ ifcb_extract_biovolumes <- function(feature_files, class_files = NULL, custom_im
     }
   }
 
-  if (use_cell_counts && !is.null(custom_images)) {
+  if (use_cell_counts && !is.null(custom_images) && is.null(custom_cell_counts)) {
     cli_abort(c(
-      "{.arg use_cell_counts = TRUE} cannot be combined with {.arg custom_images}/{.arg custom_classes}.",
-      "i" = "Chain-count data is read from {.arg class_files} ({.file .h5} or {.file .csv})."
+      "{.arg use_cell_counts = TRUE} requires {.arg custom_cell_counts} when {.arg custom_images}/{.arg custom_classes} are used.",
+      "i" = "Chain-count data is read from {.arg class_files} ({.file .h5} or {.file .csv}), or supplied per image via {.arg custom_cell_counts}."
+    ))
+  }
+
+  if (!is.null(custom_cell_counts) && is.null(custom_images)) {
+    cli_abort(c(
+      "{.arg custom_cell_counts} requires {.arg custom_images}/{.arg custom_classes}.",
+      "i" = "Chain counts supplied this way are matched to {.arg custom_images} by position."
+    ))
+  }
+
+  if (!is.null(custom_cell_counts) && !use_cell_counts) {
+    cli_abort(c(
+      "{.arg custom_cell_counts} was supplied but {.arg use_cell_counts} is {.code FALSE}.",
+      "i" = "Set {.arg use_cell_counts = TRUE} to use the supplied chain counts."
+    ))
+  }
+
+  if (use_cell_counts && !is.null(custom_cell_counts) && all(is.na(custom_cell_counts))) {
+    cli_abort(c(
+      "{.arg use_cell_counts = TRUE} but every {.arg custom_cell_counts} value is {.code NA}.",
+      "i" = "Supply the {.code cell_count} data from the classification files, or set {.arg use_cell_counts = FALSE}."
     ))
   }
 
@@ -336,12 +374,38 @@ ifcb_extract_biovolumes <- function(feature_files, class_files = NULL, custom_im
       ))
     }
 
+    if (!is.null(custom_cell_counts) && length(custom_cell_counts) != length(custom_images)) {
+      cli_abort(c(
+        "The number of images does not match the number of chain counts.",
+        "x" = "{.arg custom_images} has length {length(custom_images)}",
+        "x" = "{.arg custom_cell_counts} has length {length(custom_cell_counts)}"
+      ))
+    }
+
     image_df <- ifcb_convert_filenames(custom_images)
     class_df <- image_df %>%
       mutate(classifier = NA,
              class = custom_classes) %>%
       select(sample, classifier, roi, class) %>%
       rename(roi_number = roi)
+
+    if (use_cell_counts) {
+      class_df$cell_count <- as.integer(custom_cell_counts)
+
+      # Mirror the class_files diagnostics: a missing count nulls the whole
+      # sample-class group in ifcb_summarize_biovolumes(), so say which
+      # samples are affected rather than surface an unexplained NA. Not gated
+      # on `verbose`: this reports a data-integrity condition that changes
+      # the returned numbers, not progress.
+      n_na <- sum(is.na(class_df$cell_count))
+      if (n_na > 0) {
+        na_samples <- unique(class_df$sample[is.na(class_df$cell_count)])
+        cli_warn(c(
+          "{n_na} of {nrow(class_df)} {.arg custom_cell_counts} value{qty(n_na)}{?s} {?is/are} {.code NA}.",
+          "i" = "{.field cell_counts} is {.code NA} for the affected sample{qty(length(na_samples))}{?s}: {.val {na_samples}}."
+        ))
+      }
+    }
 
   } else {
     # Find unique samples in biovolume_df

--- a/R/ifcb_summarize_biovolumes.R
+++ b/R/ifcb_summarize_biovolumes.R
@@ -20,6 +20,11 @@ utils::globalVariables(c("biovolume_um3", "carbon_pg", "counts", "classifier", "
 #'        These filenames should match the `roi_number` assignment in the `feature_files` and can be
 #'        used as a substitute for classification files.
 #' @param custom_classes (Optional) A character vector of corresponding class labels for `custom_images`.
+#' @param custom_cell_counts (Optional) An integer vector of raw per-ROI chain counts
+#'   corresponding to `custom_images` by position, as produced by the diatom chain counter
+#'   (the `cell_count` data in `.mat`/`.h5`/`.csv` classification files). Sentinel values
+#'   (`-1`, `0`) and `NA` are allowed and resolved exactly as when reading `class_files`.
+#'   Requires `use_cell_counts = TRUE`. Passed to \code{ifcb_extract_biovolumes}. Default: NULL.
 #' @param micron_factor Conversion factor from microns per pixel (default: 1/3.4).
 #' @param diatom_class A character vector of diatom class names in the World Register of Marine Species (WoRMS). Default is "Bacillariophyceae".
 #' @param diatom_include Optional character vector of class names that should always be treated as diatoms,
@@ -49,8 +54,9 @@ utils::globalVariables(c("biovolume_um3", "carbon_pg", "counts", "classifier", "
 #' @param use_cell_counts Logical. If `TRUE`, reads the optional per-ROI `cell_count` data
 #'   stored by the diatom chain counter in `.mat`/`.h5`/`.csv` classification files and adds
 #'   `cell_counts` (and `cell_counts_per_liter` when `hdr_folder` is supplied) to the output,
-#'   reporting cell abundance alongside ROI counts. Only supported with automated `class_files`.
-#'   The function aborts if enabled but no classification file contains chain-count data. For
+#'   reporting cell abundance alongside ROI counts. Supported with automated `class_files`,
+#'   or with `custom_images` when the counts are supplied via `custom_cell_counts`.
+#'   The function aborts if enabled but no chain-count data is available. For
 #'   chain-length statistics (mean, median, max chain length) use
 #'   \code{\link{ifcb_summarize_cell_counts}}. Note that `cell_counts` here is summed only over
 #'   ROIs that also have matching feature (biovolume) data (the same ROI population as `counts`);
@@ -138,6 +144,7 @@ utils::globalVariables(c("biovolume_um3", "carbon_pg", "counts", "classifier", "
 #' @export
 ifcb_summarize_biovolumes <- function(feature_folder, class_files = NULL, class2use_file = NULL,
                                       hdr_folder = NULL, custom_images = NULL, custom_classes = NULL,
+                                      custom_cell_counts = NULL,
                                       micron_factor = 1 / 3.4, diatom_class = "Bacillariophyceae", diatom_include = NULL,
                                       marine_only = FALSE, diatom_equation = c("large", "all", "auto"),
                                       threshold = "opt", feature_recursive = TRUE,
@@ -175,6 +182,7 @@ ifcb_summarize_biovolumes <- function(feature_folder, class_files = NULL, class2
                                         class_files = class_files,
                                         custom_images = custom_images,
                                         custom_classes = custom_classes,
+                                        custom_cell_counts = custom_cell_counts,
                                         class2use_file = class2use_file,
                                         micron_factor = micron_factor,
                                         diatom_class = diatom_class,

--- a/man/ifcb_extract_biovolumes.Rd
+++ b/man/ifcb_extract_biovolumes.Rd
@@ -9,6 +9,7 @@ ifcb_extract_biovolumes(
   class_files = NULL,
   custom_images = NULL,
   custom_classes = NULL,
+  custom_cell_counts = NULL,
   class2use_file = NULL,
   micron_factor = 1/3.4,
   diatom_class = "Bacillariophyceae",
@@ -47,6 +48,14 @@ These filenames should match the \code{roi_number} assignment in the \code{featu
 used as a substitute for classification files.}
 
 \item{custom_classes}{(Optional) A character vector of corresponding class labels for \code{custom_images}.}
+
+\item{custom_cell_counts}{(Optional) An integer vector of raw per-ROI chain counts
+corresponding to \code{custom_images} by position, as produced by the diatom chain
+counter (the \code{cell_count} data in \code{.mat}/\code{.h5}/\code{.csv} classification files).
+Sentinel values (\code{-1} for ROIs the counter skipped, \code{0} where it found no
+cells) and \code{NA} (no chain-count data for that ROI) are allowed and resolved
+exactly as when reading \code{class_files}; see \code{single_cell_values}. Requires
+\code{use_cell_counts = TRUE}. Default: NULL.}
 
 \item{class2use_file}{(Optional) A character string specifying the path to the file containing the \code{class2use} variable. Only required for manual results (default: NULL).}
 
@@ -96,8 +105,9 @@ class without any threshold applied.}
 \item{use_cell_counts}{Logical. If \code{TRUE}, reads the optional per-ROI \code{cell_count}
 data stored by the diatom chain counter in \code{.mat}/\code{.h5}/\code{.csv} classification files and
 adds \code{cell_count} (raw) and \code{cell_count_resolved} (resolved abundance) columns to the
-output. Only supported with automated \code{class_files}; not with manual files
-or \code{custom_images}. Default: \code{FALSE}.}
+output. Supported with automated \code{class_files}, or with \code{custom_images} when
+the counts are supplied via \code{custom_cell_counts}; not with manual files.
+Default: \code{FALSE}.}
 
 \item{single_cell_values}{Integer vector of \code{cell_count} values that should be treated
 as a single cell when resolving \code{cell_count_resolved}. Default is \code{c(-1, 0)}, i.e. ROIs that
@@ -156,6 +166,7 @@ depending on whether the class is identified as a diatom.
 \itemize{
 \item If \code{class_files} is provided, the function reads class annotations from \code{.mat}, \code{.h5}, or \code{.csv} files.
 \item If \code{custom_images} and \code{custom_classes} are supplied, they override classification file data (e.g. data from a CNN model).
+Chain counts can then be supplied per image via \code{custom_cell_counts} to use \code{use_cell_counts = TRUE}.
 \item If both \code{class_files} and \code{custom_images/custom_classes} are given, \code{class_files} takes precedence.
 }
 \item \strong{MAT File Processing:}

--- a/man/ifcb_summarize_biovolumes.Rd
+++ b/man/ifcb_summarize_biovolumes.Rd
@@ -11,6 +11,7 @@ ifcb_summarize_biovolumes(
   hdr_folder = NULL,
   custom_images = NULL,
   custom_classes = NULL,
+  custom_cell_counts = NULL,
   micron_factor = 1/3.4,
   diatom_class = "Bacillariophyceae",
   diatom_include = NULL,
@@ -53,6 +54,12 @@ used as a substitute for classification files.}
 
 \item{custom_classes}{(Optional) A character vector of corresponding class labels for \code{custom_images}.}
 
+\item{custom_cell_counts}{(Optional) An integer vector of raw per-ROI chain counts
+corresponding to \code{custom_images} by position, as produced by the diatom chain counter
+(the \code{cell_count} data in \code{.mat}/\code{.h5}/\code{.csv} classification files). Sentinel values
+(\code{-1}, \code{0}) and \code{NA} are allowed and resolved exactly as when reading \code{class_files}.
+Requires \code{use_cell_counts = TRUE}. Passed to \code{ifcb_extract_biovolumes}. Default: NULL.}
+
 \item{micron_factor}{Conversion factor from microns per pixel (default: 1/3.4).}
 
 \item{diatom_class}{A character vector of diatom class names in the World Register of Marine Species (WoRMS). Default is "Bacillariophyceae".}
@@ -93,8 +100,9 @@ class without any threshold applied.}
 \item{use_cell_counts}{Logical. If \code{TRUE}, reads the optional per-ROI \code{cell_count} data
 stored by the diatom chain counter in \code{.mat}/\code{.h5}/\code{.csv} classification files and adds
 \code{cell_counts} (and \code{cell_counts_per_liter} when \code{hdr_folder} is supplied) to the output,
-reporting cell abundance alongside ROI counts. Only supported with automated \code{class_files}.
-The function aborts if enabled but no classification file contains chain-count data. For
+reporting cell abundance alongside ROI counts. Supported with automated \code{class_files},
+or with \code{custom_images} when the counts are supplied via \code{custom_cell_counts}.
+The function aborts if enabled but no chain-count data is available. For
 chain-length statistics (mean, median, max chain length) use
 \code{\link{ifcb_summarize_cell_counts}}. Note that \code{cell_counts} here is summed only over
 ROIs that also have matching feature (biovolume) data (the same ROI population as \code{counts});

--- a/tests/testthat/test-ifcb_extract_biovolumes.R
+++ b/tests/testthat/test-ifcb_extract_biovolumes.R
@@ -413,6 +413,162 @@ test_that("ifcb_extract_biovolumes aborts when a sample resolves to two class fi
   # same class folder.
 })
 
+test_that("custom_cell_counts input is validated", {
+  images <- c("D20220522T003051_IFCB134_00002", "D20220522T003051_IFCB134_00003")
+  classes <- rep("Chaetoceros_sp", 2)
+
+  # The 0.10.0 abort survives when no counts are supplied, with new guidance.
+  expect_error(
+    ifcb_extract_biovolumes(feature_folder, custom_images = images,
+                            custom_classes = classes, use_cell_counts = TRUE,
+                            verbose = FALSE),
+    "requires.*custom_cell_counts"
+  )
+
+  # Counts are positional against custom_images, so they mean nothing without them.
+  expect_error(
+    ifcb_extract_biovolumes(feature_folder, class_folder,
+                            custom_cell_counts = c(4L, 5L),
+                            use_cell_counts = TRUE, verbose = FALSE),
+    "requires.*custom_images"
+  )
+
+  # Counts without use_cell_counts = TRUE would be silently ignored otherwise.
+  expect_error(
+    ifcb_extract_biovolumes(feature_folder, custom_images = images,
+                            custom_classes = classes,
+                            custom_cell_counts = c(4L, 5L), verbose = FALSE),
+    "use_cell_counts"
+  )
+
+  # All-NA counts mirror the "none of the classification files contain
+  # chain-count data" abort of the class_files path.
+  expect_error(
+    ifcb_extract_biovolumes(feature_folder, custom_images = images,
+                            custom_classes = classes,
+                            custom_cell_counts = c(NA_integer_, NA_integer_),
+                            use_cell_counts = TRUE, verbose = FALSE),
+    "every.*NA"
+  )
+
+  # Length mismatch, like the images/classes check.
+  expect_error(
+    ifcb_extract_biovolumes(feature_folder, custom_images = images,
+                            custom_classes = classes,
+                            custom_cell_counts = 4L,
+                            use_cell_counts = TRUE, verbose = FALSE),
+    "number of images does not match the number of chain counts"
+  )
+
+  # ifcb_summarize_biovolumes() passes the argument through, so it must
+  # reject the same input.
+  expect_error(
+    ifcb_summarize_biovolumes(feature_folder, custom_images = images,
+                              custom_classes = classes, use_cell_counts = TRUE,
+                              verbose = FALSE),
+    "requires.*custom_cell_counts"
+  )
+})
+
+test_that("custom_cell_counts reproduces the class_files chain-count results", {
+  skip_if_offline()
+  skip_on_cran()
+  skip_if_not_installed("hdf5r")
+  skip_if_resource_unavailable("https://marinespecies.org")
+
+  # A synthetic .h5 covering the ROIs of the real feature file gives the
+  # class_files reference; the custom path is fed the same classes and counts
+  # per image and must return identical numbers.
+  chain_dir <- file.path(tempdir(), "ifcb_extract_biovolumes_custom")
+  dir.create(chain_dir, showWarnings = FALSE)
+  on.exit(unlink(chain_dir, recursive = TRUE), add = TRUE)
+
+  cl <- "Chaetoceros_sp"
+  f <- hdf5r::H5File$new(file.path(chain_dir, "D20220522T003051_IFCB134_class.h5"),
+                         mode = "w")
+  f[["class_labels"]] <- cl
+  f[["roi_numbers"]] <- c(2L, 3L)
+  f[["output_scores"]] <- matrix(0.9, nrow = 1, ncol = 2)
+  f[["classifier_name"]] <- "test_clf"
+  f[["class_name_auto"]] <- rep(cl, 2)
+  f[["class_name"]] <- rep(cl, 2)
+  f[["thresholds"]] <- 0.5
+  f[["cell_count"]] <- c(4L, 5L)
+  f$close_all()
+
+  images <- c("D20220522T003051_IFCB134_00002", "D20220522T003051_IFCB134_00003")
+
+  from_files <- ifcb_extract_biovolumes(feature_folder, chain_dir,
+                                        use_cell_counts = TRUE,
+                                        carbon_conversion = "cell",
+                                        verbose = FALSE)
+  from_custom <- ifcb_extract_biovolumes(feature_folder,
+                                         custom_images = images,
+                                         custom_classes = rep(cl, 2),
+                                         custom_cell_counts = c(4L, 5L),
+                                         use_cell_counts = TRUE,
+                                         carbon_conversion = "cell",
+                                         verbose = FALSE)
+
+  expect_identical(names(from_files), names(from_custom))
+  expect_equal(from_custom$cell_count, from_files$cell_count)
+  expect_equal(from_custom$cell_count_resolved, from_files$cell_count_resolved)
+  expect_equal(from_custom$biovolume_um3, from_files$biovolume_um3)
+  expect_equal(from_custom$carbon_pg, from_files$carbon_pg)
+
+  # Sentinels resolve to one cell exactly as when read from files.
+  sentinels <- ifcb_extract_biovolumes(feature_folder,
+                                       custom_images = images,
+                                       custom_classes = rep(cl, 2),
+                                       custom_cell_counts = c(-1L, 0L),
+                                       use_cell_counts = TRUE,
+                                       verbose = FALSE)
+  expect_equal(sentinels$cell_count_resolved, c(1L, 1L))
+
+  # And the summarize wrapper carries the counts into cell_counts.
+  summary_custom <- ifcb_summarize_biovolumes(feature_folder,
+                                              custom_images = images,
+                                              custom_classes = rep(cl, 2),
+                                              custom_cell_counts = c(4L, 5L),
+                                              use_cell_counts = TRUE,
+                                              carbon_conversion = "cell",
+                                              verbose = FALSE)
+  expect_true("cell_counts" %in% names(summary_custom))
+  expect_equal(summary_custom$cell_counts[summary_custom$class == cl], 9)
+})
+
+test_that("a missing custom_cell_counts value warns and nulls the sample's cell_counts", {
+  skip_if_offline()
+  skip_on_cran()
+  skip_if_resource_unavailable("https://marinespecies.org")
+
+  cl <- "Chaetoceros_sp"
+  images <- c("D20220522T003051_IFCB134_00002", "D20220522T003051_IFCB134_00003")
+
+  expect_warning(
+    res <- ifcb_extract_biovolumes(feature_folder,
+                                   custom_images = images,
+                                   custom_classes = rep(cl, 2),
+                                   custom_cell_counts = c(4L, NA_integer_),
+                                   use_cell_counts = TRUE,
+                                   verbose = FALSE),
+    "NA"
+  )
+  expect_equal(res$cell_count[res$roi_number == 2], 4L)
+  expect_true(is.na(res$cell_count[res$roi_number == 3]))
+
+  # The partly-NA group is reported as NA cell_counts, never a partial sum.
+  suppressWarnings(
+    summary_na <- ifcb_summarize_biovolumes(feature_folder,
+                                            custom_images = images,
+                                            custom_classes = rep(cl, 2),
+                                            custom_cell_counts = c(4L, NA_integer_),
+                                            use_cell_counts = TRUE,
+                                            verbose = FALSE)
+  )
+  expect_true(is.na(summary_na$cell_counts[summary_na$class == cl]))
+})
+
 unlink(temp_dir, recursive = TRUE)
 
 test_that("a missing cell_count inside a chain-counted file warns in ifcb_extract_biovolumes", {


### PR DESCRIPTION
…ions

use_cell_counts = TRUE (and carbon_conversion = "cell") now works with custom_images/custom_classes by supplying the per-ROI chain counts via the new custom_cell_counts argument, matched by position. The counts follow the same semantics as counts read from classification files: sentinels resolve via single_cell_values, and an NA marks a ROI without chain-count data, making the affected sample's cell_counts NA rather than a silent partial sum (reported with a warning naming the samples). Wrong-length input, all-NA input, counts without custom_images, and counts without use_cell_counts = TRUE each fail with an error saying what to change.